### PR TITLE
CD pipeline improvements

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -34,6 +34,64 @@ jobs:
           platforms: linux/amd64,linux/arm/v8
           tags: 'ghcr.io/day-fit/encryptify-core:latest', 'ghcr.io/day-fit/encryptify-core:${{ github.event.release.tag_name }}'
 
+  build-auth:
+    name: Build Encryptify-Auth Image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          file: ./dockerfiles/dockerfile-auth
+          platforms: linux/amd64,linux/arm/v8
+          tags: 'ghcr.io/day-fit/encryptify-auth:latest', 'ghcr.io/day-fit/encryptify-auth:${{ github.event.release.tag_name }}'
+
+  build-email:
+    name: Build Encryptify-Email Image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          file: ./dockerfiles/dockerfile-email
+          platforms: linux/amd64,linux/arm/v8
+          tags: 'ghcr.io/day-fit/encryptify-email:latest', 'ghcr.io/day-fit/encryptify-email:${{ github.event.release.tag_name }}'
+
   build-encryption:
     name: Build Encryptify-Encryption Image
     runs-on: ubuntu-22.04

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -19,10 +19,25 @@
           <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct-processor/1.6.3/mapstruct-processor-1.6.3.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.6.3/mapstruct-1.6.3.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.38/lombok-1.18.38.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct-processor/1.6.3/mapstruct-processor-1.6.3.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.6.3/mapstruct-1.6.3.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
         </processorPath>
-        <module name="encryptify-auth" />
         <module name="encryptify-core" />
         <module name="encryptify-encryption" />
+      </profile>
+      <profile name="Annotation profile for encryptify-auth" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.38/lombok-1.18.38.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct-processor/1.6.3/mapstruct-processor-1.6.3.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.6.3/mapstruct-1.6.3.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
+        </processorPath>
+        <module name="encryptify-auth" />
       </profile>
     </annotationProcessing>
   </component>

--- a/dockerfiles/dockerfile-auth
+++ b/dockerfiles/dockerfile-auth
@@ -18,4 +18,4 @@ RUN \
 
 CMD ["java", "-jar", "/app/encryptify-auth.jar"]
 
-EXPOSE 8080
+EXPOSE 8083

--- a/dockerfiles/dockerfile-auth
+++ b/dockerfiles/dockerfile-auth
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:21.0.7_6-jdk-alpine-3.21
+
+LABEL name="encryptify-auth"
+LABEL maintainer="Dayfit"
+LABEL description="Encryptify Auth Service"
+
+COPY ./.mvn /app/.mvn
+COPY ./mvnw /app/mvnw
+
+COPY ./encryptify-auth /app/encryptify-auth
+WORKDIR /app
+
+# Compile source code
+RUN \
+    cd /app/encryptify-auth && \
+    ../mvnw package -DskipTests && \
+    mv /app/encryptify-core/target/encryptify-auth-*.jar /app/encryptify-auth.jar
+
+CMD ["java", "-jar", "/app/encryptify-auth.jar"]
+
+EXPOSE 8080

--- a/dockerfiles/dockerfile-email
+++ b/dockerfiles/dockerfile-email
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:21.0.7_6-jdk-alpine-3.21
+
+LABEL name="encryptify-email"
+LABEL maintainer="Dayfit"
+LABEL description="Encryptify Email Service"
+
+COPY ./.mvn /app/.mvn
+COPY ./mvnw /app/mvnw
+
+COPY ./encryptify-email /app/encryptify-email
+WORKDIR /app
+
+# Compile source code
+RUN \
+    cd /app/encryptify-email && \
+    ../mvnw package -DskipTests && \
+    mv /app/encryptify-core/target/encryptify-email-*.jar /app/encryptify-email.jar
+
+CMD ["java", "-jar", "/app/encryptify-email.jar"]
+
+EXPOSE 8082


### PR DESCRIPTION
This pull request adds support for building and deploying the new `encryptify-auth` and `encryptify-email` services as Docker images, alongside updates to project configuration for annotation processing. The main changes are grouped into CI/CD workflow enhancements, Dockerfile additions, and IDE configuration updates.

**CI/CD Workflow Enhancements:**

* Added `build-auth` and `build-email` jobs to `.github/workflows/build-docker.yaml` to automate building and pushing Docker images for the `encryptify-auth` and `encryptify-email` services to GHCR. Each job sets up Docker, checks out the repo, and builds/pushes the respective image for multiple platforms.

**Dockerfile Additions:**

* Introduced new `dockerfiles/dockerfile-auth` for the `encryptify-auth` service, specifying the base image, copying source files, compiling the service, and setting up the container entrypoint and exposed port.

**IDE Configuration Updates:**

* Updated `.idea/compiler.xml` to add a dedicated annotation processing profile for the `encryptify-auth` module, ensuring correct handling of Lombok and MapStruct dependencies during compilation.